### PR TITLE
add expand json option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Required Embulk version >= 0.9.20
 - **columns** target issue attributes. You can generate this configuration by `guess` command (array, required)
 - **retry_initial_wait_sec**: Wait seconds for exponential backoff initial value (integer, default: 1)
 - **retry_limit**: Try to retry this times (integer, default: 5)
+- **expand_json_on_guess** The boolean value is to enable/disable json expanding when `guess`. (boolean, default: true)
 
 ## Example
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ configurations {
     provided
 }
 
-version = "0.2.10"
+version = "0.2.11"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/org/embulk/input/jira/Issue.java
+++ b/src/main/java/org/embulk/input/jira/Issue.java
@@ -58,16 +58,16 @@ public class Issue
         }
     }
 
-    public synchronized JsonObject getFlatten()
+    public synchronized JsonObject getFlatten(Boolean expandJsonOnGuess)
     {
         if (flatten == null) {
             flatten = new JsonObject();
-            manipulatingFlattenJson(json, "");
+            manipulatingFlattenJson(json, "", expandJsonOnGuess);
         }
         return flatten;
     }
 
-    private void manipulatingFlattenJson(JsonElement in, String prefix)
+    private void manipulatingFlattenJson(JsonElement in, String prefix, boolean expandJsonOnGuess)
     {
         if (in.isJsonObject()) {
             JsonObject obj = in.getAsJsonObject();
@@ -83,7 +83,12 @@ public class Issue
                 for (Entry<String, JsonElement> entry : obj.entrySet()) {
                     String key = entry.getKey();
                     JsonElement value = entry.getValue();
-                    manipulatingFlattenJson(value, appendPrefix(prefix, key));
+                    if (expandJsonOnGuess) {
+                        manipulatingFlattenJson(value, appendPrefix(prefix, key), expandJsonOnGuess);
+                    }
+                    else {
+                        flatten.add(key, value);
+                    }
                 }
             }
         }
@@ -106,7 +111,7 @@ public class Issue
                         newObj.get(key).getAsJsonArray().add(elem.getAsJsonObject().get(key));
                     }
                 }
-                manipulatingFlattenJson(newObj, prefix);
+                manipulatingFlattenJson(newObj, prefix, expandJsonOnGuess);
             }
             else {
                 flatten.add(prefix,

--- a/src/test/java/org/embulk/input/jira/IssueTest.java
+++ b/src/test/java/org/embulk/input/jira/IssueTest.java
@@ -31,7 +31,7 @@ public class IssueTest
         String testName = "simple";
         Issue issue = new Issue(flattenData.get(testName).getAsJsonObject());
         JsonObject expected = flattenExpected.get(testName).getAsJsonObject();
-        assertEquals(expected, issue.getFlatten());
+        assertEquals(expected, issue.getFlatten(true));
     }
 
     @Test
@@ -40,7 +40,7 @@ public class IssueTest
         String testName = "twoLevels";
         Issue issue = new Issue(flattenData.get(testName).getAsJsonObject());
         JsonObject expected = flattenExpected.get(testName).getAsJsonObject();
-        assertEquals(expected, issue.getFlatten());
+        assertEquals(expected, issue.getFlatten(true));
     }
 
     @Test
@@ -49,7 +49,7 @@ public class IssueTest
         String testName = "threeLevels";
         Issue issue = new Issue(flattenData.get(testName).getAsJsonObject());
         JsonObject expected = flattenExpected.get(testName).getAsJsonObject();
-        assertEquals(expected, issue.getFlatten());
+        assertEquals(expected, issue.getFlatten(true));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class IssueTest
         String testName = "threeLevelsWithoutKeys";
         Issue issue = new Issue(flattenData.get(testName).getAsJsonObject());
         JsonObject expected = flattenExpected.get(testName).getAsJsonObject();
-        assertEquals(expected, issue.getFlatten());
+        assertEquals(expected, issue.getFlatten(true));
     }
 
     @Test
@@ -67,7 +67,7 @@ public class IssueTest
         String testName = "threeLevelsWithKeys";
         Issue issue = new Issue(flattenData.get(testName).getAsJsonObject());
         JsonObject expected = flattenExpected.get(testName).getAsJsonObject();
-        assertEquals(expected, issue.getFlatten());
+        assertEquals(expected, issue.getFlatten(true));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class IssueTest
         String testName = "threeLevelsWithNullKeys";
         Issue issue = new Issue(flattenData.get(testName).getAsJsonObject());
         JsonObject expected = flattenExpected.get(testName).getAsJsonObject();
-        assertEquals(expected, issue.getFlatten());
+        assertEquals(expected, issue.getFlatten(true));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class IssueTest
         String testName = "arrayWithAllJsonObjectWithSameKeysAndEmptyObject";
         Issue issue = new Issue(flattenData.get(testName).getAsJsonObject());
         JsonObject expected = flattenExpected.get(testName).getAsJsonObject();
-        assertEquals(expected, issue.getFlatten());
+        assertEquals(expected, issue.getFlatten(true));
     }
 
     @Test
@@ -94,7 +94,7 @@ public class IssueTest
         String testName = "arrayWithAllJsonObjectWithSameKeysAndNotEmptyObject";
         Issue issue = new Issue(flattenData.get(testName).getAsJsonObject());
         JsonObject expected = flattenExpected.get(testName).getAsJsonObject();
-        assertEquals(expected, issue.getFlatten());
+        assertEquals(expected, issue.getFlatten(true));
     }
 
     @Test
@@ -103,7 +103,7 @@ public class IssueTest
         String testName = "arrayWithAllJsonObjectWithoutSameKeys";
         Issue issue = new Issue(flattenData.get(testName).getAsJsonObject());
         JsonObject expected = flattenExpected.get(testName).getAsJsonObject();
-        assertEquals(expected, issue.getFlatten());
+        assertEquals(expected, issue.getFlatten(true));
     }
 
     @Test


### PR DESCRIPTION
In some databases, you cannot use `.` in column names.
This option allows you to choose whether or not to expand `json` columns on `guess`.