### PR TITLE
fix to treat JsonNull as no type (type = null)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     }
     compile('org.embulk:embulk-util-retryhelper-jetty92:0.8.2')
     compile 'org.embulk:embulk-util-timestamp:0.2.1'
-    compile('org.embulk:embulk-util-guess:0.1.2')
+    compile('org.embulk:embulk-util-guess:0.2.0')
 
     compile('org.embulk:embulk-util-json:0.1.1') {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'

--- a/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -25,13 +25,13 @@ org.eclipse.jetty:jetty-http:9.2.14.v20151106
 org.eclipse.jetty:jetty-io:9.2.14.v20151106
 org.eclipse.jetty:jetty-util:9.2.14.v20151106
 org.embulk:embulk-util-config:0.3.1
-org.embulk:embulk-util-file:0.1.1
-org.embulk:embulk-util-guess:0.1.2
+org.embulk:embulk-util-file:0.1.3
+org.embulk:embulk-util-guess:0.2.0
 org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-retryhelper-jetty92:0.8.2
 org.embulk:embulk-util-retryhelper:0.8.2
 org.embulk:embulk-util-rubytime:0.3.2
-org.embulk:embulk-util-text:0.1.0
+org.embulk:embulk-util-text:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.glassfish.hk2.external:javax.inject:2.5.0-b42
 org.glassfish.hk2:osgi-resource-locator:1.0.1

--- a/src/main/java/org/embulk/input/jira/util/JiraUtil.java
+++ b/src/main/java/org/embulk/input/jira/util/JiraUtil.java
@@ -273,6 +273,9 @@ public final class JiraUtil
             if (elem.isJsonPrimitive()) {
                 result.put(key, flt.get(key).getAsString());
             }
+            else if(elem.isJsonNull()) {
+                result.put(key, null);
+            }
             else {
                 result.put(key, elem);
             }


### PR DESCRIPTION
With the current code, JsonNull is treated as json.
If the first 50 records doesn't have values in a certain cell, "embulk guess" will treat the cell as json (guessed from JsonNull).

I fixed `JiraUtil.toLinkedHashMap` to set `null` if JSON's value is JsonNull.
By this fix, type will be `null`, then embulk-util-guess cannot handle type == null correctly due to a bug.
ref: [Fix guessing a timestamp format from null (Fix #25) by dmikurube · Pull Request #23 · embulk/embulk-util-guess](https://github.com/embulk/embulk-util-guess/pull/23)
So I bumped embulk-util-guess to `0.2.0` too in order to fix this bug.
