### PR TITLE
Fix JQL Japanese character encoding issue

### DIFF
--- a/src/main/java/org/embulk/input/jira/client/JiraClient.java
+++ b/src/main/java/org/embulk/input/jira/client/JiraClient.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -225,7 +226,7 @@ public class JiraClient
             request.setHeader(CONTENT_TYPE, "application/json");
             break;
         }
-        request.setEntity(new StringEntity(body));
+        request.setEntity(new StringEntity(body, StandardCharsets.UTF_8));
         return request;
     }
 

--- a/src/main/java/org/embulk/input/jira/client/JiraClient.java
+++ b/src/main/java/org/embulk/input/jira/client/JiraClient.java
@@ -223,7 +223,7 @@ public class JiraClient
                                 task.getUsername(),
                                 task.getPassword()).getBytes())));
             request.setHeader(ACCEPT, "application/json");
-            request.setHeader(CONTENT_TYPE, "application/json");
+            request.setHeader(CONTENT_TYPE, "application/json; charset=UTF-8");
             break;
         }
         request.setEntity(new StringEntity(body, StandardCharsets.UTF_8));

--- a/src/test/java/org/embulk/input/jira/client/JiraClientTest.java
+++ b/src/test/java/org/embulk/input/jira/client/JiraClientTest.java
@@ -182,4 +182,26 @@ public class JiraClientTest
         issues = result.getLeft();
         assertEquals(issues.size(), 2);
     }
+
+    @Test
+    public void test_searchIssues_withJapaneseJql() throws IOException
+    {
+        String dataName = "searchIssuesWithJapaneseJql";
+        JsonObject messageResponse = data.get(dataName).getAsJsonObject();
+
+        int statusCode = messageResponse.get("statusCode").getAsInt();
+        String body = messageResponse.get("body").toString();
+
+        when(statusLine.getStatusCode()).thenReturn(statusCode);
+        when(response.getEntity()).thenReturn(new StringEntity(body, "UTF-8"));
+
+        ConfigSource config = TestHelpers.config().set("jql", "labels=\"テスト\"");
+        task = CONFIG_MAPPER.map(config, PluginTask.class);
+
+        Pair<List<Issue>, String> result = jiraClient.searchIssues(task, null, 50);
+        List<Issue> issues = result.getLeft();
+        assertEquals(1, issues.size());
+        assertEquals("TEST-1", issues.get(0).getValue("key").getAsString());
+        assertEquals("テスト", issues.get(0).getValue("string").getAsString());
+    }
 }

--- a/src/test/resources/jira_client.json
+++ b/src/test/resources/jira_client.json
@@ -77,5 +77,28 @@
             ],
             "errors": {}
         }
+    },
+    "searchIssuesWithJapaneseJql": {
+        "statusCode": 200,
+        "body": {
+            "startAt": 0,
+            "maxResults": 50,
+            "total": 1,
+            "issues": [
+                {
+                    "id": "id1",
+                    "key": "TEST-1",
+                    "self": "self1",
+                    "fields": {
+                        "boolean": true,
+                        "long": 1,
+                        "double": 1,
+                        "string": "テスト",
+                        "date": "2019-01-01T00:00:00.000Z",
+                        "json": {}
+                    }
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fix an error that occurs when JQL queries contain Japanese characters
- The issue was caused by StringEntity defaulting to ISO-8859-1 encoding instead of UTF-8
- Explicitly specify UTF-8 encoding to properly handle Japanese and other multibyte characters

## Problem
When using Japanese characters in JQL queries (e.g., `labels="テスト"`), the following error occurred:
```
Error: Could not guess schema due to empty data set
```

However, the same query works correctly when using curl with `--data-urlencode` option.

## Root Cause
In `JiraClient.java:228`, the `StringEntity` constructor was called without specifying character encoding:
```java
request.setEntity(new StringEntity(body));
```

Apache HttpClient 4.x defaults to ISO-8859-1 encoding when no encoding is specified, which causes Japanese characters to be incorrectly encoded when sent to the JIRA API.

This issue was introduced in commit 2692818 "use new jql search API (#6)" when the implementation was changed to use POST requests with JSON body instead of GET requests with query parameters.

## Changes
### Modified Files
- `src/main/java/org/embulk/input/jira/client/JiraClient.java`
  - Added `StandardCharsets` import
  - Changed `new StringEntity(body)` to `new StringEntity(body, StandardCharsets.UTF_8)`
  
- `src/test/java/org/embulk/input/jira/client/JiraClientTest.java`
  - Added test case `test_searchIssues_withJapaneseJql()` to verify Japanese JQL queries work correctly
  
- `src/test/resources/jira_client.json`
  - Added test data for Japanese JQL query test case

## Testing
- ✅ All existing tests pass
- ✅ New Japanese JQL query test case passes
- ✅ Verified UTF-8 encoding in compiled bytecode using javap

🤖 Generated with [Claude Code](https://claude.com/claude-code)